### PR TITLE
make function signature (options, fn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ they were rather difficult to use or do not offer an easy to do conditional retr
 
 ## Usage
 
-### promiseRetry(fn, [options])
+### promiseRetry([options], fn)
 
 Calls `fn` until the returned promise ends up fulfilled or rejected with an error different than
 a `retry` error.   

--- a/index.js
+++ b/index.js
@@ -3,14 +3,28 @@
 var errcode = require('err-code');
 var retry = require('retry');
 var Promise = require('bluebird');
-
 var hasOwn = Object.prototype.hasOwnProperty;
 
 function isRetryError(err) {
     return err && err.code === 'EPROMISERETRY' && hasOwn.call(err, 'retried');
 }
 
-function promiseRetry(fn, options) {
+function promiseRetry(options, fn) {
+    var temp;
+
+    if (!fn && typeof(options) === 'function') {
+        // options is optional
+        fn = options;
+        options = null;
+    }
+
+    if (typeof(fn) === 'object' && typeof(options) === 'function') {
+        // swap options and fn when using old function signature of (fn, options)
+        temp = options;
+        options = fn;
+        fn = temp;
+    }
+
     var operation = retry.operation(options);
 
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
I know that `fn` is not a "callback" in this api per-se, but I'd argue that it is still best practice to put the options first. It makes the code easier to read because you immediately see the options being passed, instead of having to scroll to the end of an inlined function to find the options.

This PR makes the advertised public api be (options, fn) and supports the old api of (fn, options) for backwards compatibility. I have added a test to show that both apis work.