### PR TITLE
allow options and fn to be swapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The `fn` function will receive a `retry` function as its first argument that sho
 If there's retries left, it will throw a special `retry` error that will be handled internally to call `fn` again.
 If there's no retries left, it will throw the actual error passed to it.
 
+If you prefer, you can pass the options first using the alternative function signature `promiseRetry([options], fn)`.
 
+## Example
 ```js
 var promiseRetry = require('promise-retry');
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,15 @@ function isRetryError(err) {
 }
 
 function promiseRetry(fn, options) {
+    var temp;
+
+    if (typeof fn === 'object' && typeof options === 'function') {
+        // swap options and fn when using alternate signature (options, fn)
+        temp = options;
+        options = fn;
+        fn = temp;
+    }
+
     var operation = retry.operation(options);
 
     return new Promise(function (resolve, reject) {

--- a/test/test.js
+++ b/test/test.js
@@ -242,4 +242,27 @@ describe('promise-retry', function () {
         })
         .done(done, done);
     });
+
+    it('should allow options to be passed first', function (done) {
+        var count = 0;
+
+        promiseRetry({ factor: 1 }, function (retry) {
+            count += 1;
+
+            return Promise.delay(10)
+                .then(function () {
+                    if (count <= 2) {
+                        retry(new Error('foo'));
+                    }
+
+                    return 'final';
+                });
+        }).then(function (value) {
+            expect(value).to.be('final');
+            expect(count).to.be(3);
+        }, function () {
+            throw new Error('should not fail');
+        }).done(done, done);
+    });
+
 });


### PR DESCRIPTION
This PR replaces #1 and simply makes the (options, fn) signature an option without changing the default function signature.