### PR TITLE
expose retry's operation object and update retry to 0.12.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function promiseRetry(fn, options) {
                     }
 
                     throw errcode('Retrying', 'EPROMISERETRY', { retried: err });
-                }, number);
+                }, number, operation);
             })
             .then(resolve, function (err) {
                 if (isRetryError(err)) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "err-code": "^1.0.0",
-    "retry": "^0.10.0"
+    "retry": "^0.12.0"
   },
   "engines": {
     "node": ">=0.12"


### PR DESCRIPTION
This PR exposes ```retry```'s operation object so that it's methods (ie. operation.reset()) are accessible to the caller. Also bumps ```retry``` to 0.12.0 so that its new methods/API are available.